### PR TITLE
remove index battles (played_at)

### DIFF
--- a/app/controllers/players/battles_controller.rb
+++ b/app/controllers/players/battles_controller.rb
@@ -3,9 +3,8 @@ class Players::BattlesController < Players::BaseController
 
   def show
     result = @battles_filter_form.submit
-    # it using a nested select to prevent pg from sorting before the filter
-    @battles = Battle.from(result.ordered, "battles")
-      .ordered.reverse_order.page(params[:page]).preload(:challengers)
+
+    @battles = result.preload(:challengers).ordered.reverse_order.page(params[:page])
 
     @total_pages = cache([ @battles_filter_form, "total_pages" ]) { @battles.total_pages }
     @score = cache([ @battles_filter_form, "score" ]) { result.scores.first[1] }

--- a/db/migrate/20240918141301_remove_index_battles_on_played_at.rb
+++ b/db/migrate/20240918141301_remove_index_battles_on_played_at.rb
@@ -1,0 +1,5 @@
+class RemoveIndexBattlesOnPlayedAt < ActiveRecord::Migration[7.2]
+  def change
+    remove_index :battles, :played_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_09_12_112222) do
+ActiveRecord::Schema[7.2].define(version: 2024_09_18_141301) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -36,7 +36,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_12_112222) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["battle_type"], name: "index_battles_on_battle_type"
-    t.index ["played_at"], name: "index_battles_on_played_at"
     t.index ["replay_id"], name: "index_battles_on_replay_id", unique: true
   end
 


### PR DESCRIPTION
Makes played_at operations run in memory.

This is acceptable for now, as long as:
- all queries use at least the short_id index,
- the number of battles per player is low compared to the total number of battles
- the number of concurrent users is low