### PR TITLE
change the label for points on ranked chart

### DIFF
--- a/app/charts/ranked_history_line_chart.rb
+++ b/app/charts/ranked_history_line_chart.rb
@@ -68,12 +68,11 @@ class RankedHistoryLineChart < ApplicationChart
   end
 
   def format_label(value, variation)
-    case
-    when variation.nil? then ""
-    when variation.positive? then " + #{variation.abs}"
-    when variation.negative? then " - #{variation.abs}"
-    else " + 0"
-    end.then { "#{value}#{_1}" }
+    if variation.nil?
+      value.to_s
+    else
+      "#{value + variation} (%+d)" % variation
+    end
   end
 
   def chart_title


### PR DESCRIPTION
closes https://github.com/alanoliveira/sfbuff/issues/68

The label is showing the mr before the match + variation, for example "2000 MR + 10".
It is causing some confusion because the points seems to be misplaced. 
This PR changes it to show the total value, "2010 MR (+10)"