### PR TITLE
Fix ranked chart

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,7 +91,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
-    brakeman (7.0.0)
+    brakeman (7.0.2)
       racc
     builder (3.3.0)
     concurrent-ruby (1.3.5)

--- a/app/models/ranked_history.rb
+++ b/app/models/ranked_history.rb
@@ -17,7 +17,7 @@ class RankedHistory
     data = fetch_data
     return data if data.empty?
 
-    fetch_data.chain([ nil ]).each_cons(2).filter_map do |a, b|
+    fetch_data.sort_by(&:played_at).chain([ nil ]).each_cons(2).map do |a, b|
       unless b.nil?
         # handle MR reset
         if b["mr"].zero? ^ a["mr"].zero?
@@ -28,7 +28,7 @@ class RankedHistory
       end
       played_at = a["played_at"].in_time_zone(Time.zone)
       Item.new(a["replay_id"], played_at, a["mr"], a["lp"], mr_variation, lp_variation)
-    end.sort_by(&:played_at).each(&)
+    end.each(&)
   end
 
   def cache_key

--- a/spec/models/ranked_history_spec.rb
+++ b/spec/models/ranked_history_spec.rb
@@ -8,13 +8,13 @@ RSpec.describe RankedHistory, type: :model do
   let(:played_to) { Time.new(2025, 10, 10, 12, 0, 0) }
 
   before do
-    played_at_gen = (Time.new(2024, 10, 10, 12, 0, 0)..).step(10.minutes)
-    create_match(battle: { battle_type: "custom_room", played_at: played_at_gen.next }, p1: { fighter_id:, character:, master_rating: 1000, league_point: 5000 })
-    create_match(battle: { battle_type: "ranked", played_at: played_at_gen.next }, p1: { fighter_id:, character:, master_rating: 1000, league_point: 5000 })
-    create_match(battle: { battle_type: "ranked", played_at: played_at_gen.next }, p1: { fighter_id:, character:, master_rating: 1010, league_point: 5050 })
-    create_match(battle: { battle_type: "ranked", played_at: played_at_gen.next }, p1: { fighter_id:, character:, master_rating: 1008, league_point: 5010 })
-    create_match(battle: { battle_type: "ranked", played_at: played_at_gen.next }, p1: { fighter_id:, character:, master_rating: 0, league_point: 5040 })
-    create_match(battle: { battle_type: "ranked", played_at: played_at_gen.next }, p1: { fighter_id:, character:, master_rating: 1510, league_point: 5090 })
+    create_match(battle: { battle_type: "custom_room", played_at: Time.new(2024, 10, 10, 12, 0) }, p1: { fighter_id:, character:, master_rating: 1000, league_point: 5000 })
+    create_match(battle: { battle_type: "ranked", played_at: Time.new(2024, 10, 10, 12, 10) }, p1: { fighter_id:, character:, master_rating: 1000, league_point: 5000 })
+    create_match(battle: { battle_type: "ranked", played_at: Time.new(2024, 10, 10, 12, 20) }, p1: { fighter_id:, character:, master_rating: 1010, league_point: 5050 })
+    create_match(battle: { battle_type: "ranked", played_at: Time.new(2024, 10, 10, 12, 40) }, p1: { fighter_id:, character:, master_rating: 0, league_point: 5040 })
+    create_match(battle: { battle_type: "ranked", played_at: Time.new(2024, 10, 10, 12, 50) }, p1: { fighter_id:, character:, master_rating: 1510, league_point: 5090 })
+
+    create_match(battle: { battle_type: "ranked", played_at: Time.new(2024, 10, 10, 12, 30) }, p1: { fighter_id:, character:, master_rating: 1008, league_point: 5010 })
   end
 
   it do


### PR DESCRIPTION
The MR/LP variations was being calculated before sort the matches by date.
As result the variation could be completely wrong in some cases.

This PR changes to sort the battles before calculate the variation



Maybe related https://github.com/alanoliveira/sfbuff/issues/98
